### PR TITLE
Fixes double announcement of date.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 node_modules
 .log
 coverage

--- a/CONTRIBUTING-EMMA.md
+++ b/CONTRIBUTING-EMMA.md
@@ -1,0 +1,25 @@
+# Contributing to react-day-picker
+
+
+### Use the website to manually test changes
+
+The best way to develop and test a new idea or a bug fix is to check out the `v7` branch and run locally
+[the website](https://react-day-picker.js.org):
+
+```bash
+$ git clone -b v7 git@github.com:emmadev/react-day-picker.git
+$ cd react-day-picker
+$ cd docs
+$ yarn install
+$ yarn develop
+```
+
+Then open [localhost:8000](http://localhost:8000).
+
+> For example, change
+> [./docs/src/code-samples/examples/basic.js](./docs/src/code-samples/examples/basic.js)
+> to see it updated in
+> [localhost:8000/examples/basic](http://localhost:8000/examples/basic).
+
+In the code, using `import from react-day-picker` will load the
+[source code](src) instead of the [compiled lib](lib).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# ⚡ EMMA DEV ⚡
+
+### Please use the `v7` branch for development.
+[Docs for getting contributing](.github/CONTRIBUTING-EMMA.md)
+
+---
 <p align="center">
 <a href="http://react-day-picker.js.org"><img width="80" style="margin: 0 auto" alt="title" src="https://user-images.githubusercontent.com/120693/33364057-0d4a962a-d4e3-11e7-8506-0f9aede2b345.png"></a>
 </p>

--- a/src/Day.js
+++ b/src/Day.js
@@ -137,7 +137,6 @@ export default class Day extends Component {
         tabIndex={tabIndex}
         style={style}
         role="gridcell"
-        aria-label={ariaLabel}
         aria-disabled={ariaDisabled}
         aria-selected={ariaSelected}
         onClick={handleEvent(onClick, day, modifiers)}


### PR DESCRIPTION
## What does this work do

- Updates `README`s
- Fixes double announcements of the date
  - Removes wrapping div `aria-label` attribute
  - Leaves labeling on `button` as this looked to be the approach from [deque](https://dequeuniversity.com/library/aria/date-picker) and [w3](https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html).

## Screenshots
### Before
![Pasted_Image_7_28_20__10_46_AM](https://user-images.githubusercontent.com/78192/88689129-befffd80-d0bf-11ea-9260-5156484797c6.png)


### After
![Pasted_Image_7_28_20__10_47_AM](https://user-images.githubusercontent.com/78192/88689195-d0490a00-d0bf-11ea-88e3-1064c2faa590.png)
