### PR TITLE
Reset to base fork

### DIFF
--- a/src/Day.js
+++ b/src/Day.js
@@ -149,9 +149,7 @@ export default class Day extends Component {
         onTouchStart={handleEvent(onTouchStart, day, modifiers)}
         onFocus={handleEvent(onFocus, day, modifiers)}
       >
-        <div aria-label={ariaLabel} aria-disabled={ariaDisabled} role="button">
-          {children}
-        </div>
+        {children}
       </div>
     );
   }

--- a/src/DayPicker.js
+++ b/src/DayPicker.js
@@ -591,10 +591,6 @@ export class DayPicker extends Component {
     return (
       <div
         {...this.props.containerProps}
-        aria-modal="true"
-        aria-label="Choose Date"
-        aria-live="polite"
-        role="dialog"
         className={className}
         ref={el => (this.dayPicker = el)}
         lang={this.props.locale}


### PR DESCRIPTION
Found that we can use [`containerProps`](http://react-day-picker.js.org/api/DayPicker#containerProps) and [`renderDay`](http://react-day-picker.js.org/api/DayPicker#renderDay) options from the [`react-day-picker`](http://react-day-picker.js.org/) api to achieve desired results.